### PR TITLE
Add filter to img out end-result

### DIFF
--- a/wp-instagram-widget.php
+++ b/wp-instagram-widget.php
@@ -106,7 +106,9 @@ Class null_instagram_widget extends WP_Widget {
 					if ( locate_template( $template_part ) !== '' ) {
 						include locate_template( $template_part );
 					} else {
-						echo '<li class="' . esc_attr( $liclass ) . '"><a href="' . esc_url( $item['link'] ) . '" target="' . esc_attr( $target ) . '"  class="' . esc_attr( $aclass ) . '"><img src="' . esc_url( $item[$size] ) . '"  alt="' . esc_attr( $item['description'] ) . '" title="' . esc_attr( $item['description'] ) . '"  class="' . esc_attr( $imgclass ) . ' ' . esc_attr( $imgattribs ) . '"/></a></li>';
+						$imgoutput = '<li class="' . esc_attr( $liclass ) . '"><a href="' . esc_url( $item['link'] ) . '" target="' . esc_attr( $target ) . '"  class="' . esc_attr( $aclass ) . '"><img src="' . esc_url( $item[$size] ) . '"  alt="' . esc_attr( $item['description'] ) . '" title="' . esc_attr( $item['description'] ) . '"  class="' . esc_attr( $imgclass ) . ' ' . esc_attr( $imgattribs ) . '"/></a></li>';
+						$filteredimgoutput = apply_filters( 'wpiw_img_final_output', $imgoutput );
+						echo $filteredimgoutput;
 					}
 				}
 				?></ul><?php


### PR DESCRIPTION
Rather than having to create a separate file in a theme, add a filter to the base output so that it can be overridden in a plugin as well as a theme.

Usage example: str_replace src with data-lazy-src, then add WPRocket's lazyload src: src="data:image/gif;base64,R0lGODdhAQABAPAAAP///wAAACwAAAAAAQABAEACAkQBADs=" 

https://docs.wp-rocket.me/article/130-manually-apply-lazyload-to-an-image

Possibly even better: add separate filters for each part of the output - li, a, img